### PR TITLE
Add GitHub Pages Deployment Workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy RSS and Markdown to GitHub Pages
+
+on:
+  schedule:
+    # 8:30 PM AEST is 10:30 AM UTC
+    - cron: '30 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Install Pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Build site directory
+        run: |
+          mkdir -p public/rss
+          # Generate index.html from readme.md
+          pandoc readme.md -o public/index.html -s --metadata title="ABC Kohler Report RSS"
+          # Generate RSS feed
+          go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Added a GitHub Actions workflow that runs daily around 8:30 PM AEST to build the RSS feed and an index.html file from the readme.md, and then publishes the result to GitHub Pages.

---
*PR created automatically by Jules for task [8096471348320961631](https://jules.google.com/task/8096471348320961631) started by @arran4*