### PR TITLE
Update pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           mkdir -p public/rss
           # Generate index.html from readme.md using a Go-based markdown to HTML converter
-          go run github.com/gomarkdown/mdtohtml@latest -page readme.md public/index.html
+          go run github.com/arran4/fork-mdtohtml@latest -page readme.md public/index.html
           sed -i 's/<title>.*<\/title>/<title>ABC Kohler Report RSS<\/title>/i' public/index.html
           # Generate RSS feed
           go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,14 +31,12 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
 
-      - name: Install Pandoc
-        run: sudo apt-get update && sudo apt-get install -y pandoc
-
       - name: Build site directory
         run: |
           mkdir -p public/rss
-          # Generate index.html from readme.md
-          pandoc readme.md -o public/index.html -s --metadata title="ABC Kohler Report RSS"
+          # Generate index.html from readme.md using a Go-based markdown to HTML converter
+          go run github.com/gomarkdown/mdtohtml@latest -page readme.md public/index.html
+          sed -i 's/<title>.*<\/title>/<title>ABC Kohler Report RSS<\/title>/i' public/index.html
           # Generate RSS feed
           go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml
 


### PR DESCRIPTION
Update pages workflow to use mdtohtml instead of pandoc to make the build faster. It uses `sed` to replace the title.

---
*PR created automatically by Jules for task [16241125379441668271](https://jules.google.com/task/16241125379441668271) started by @arran4*