### PR TITLE
ci: force create and push git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,7 @@ jobs:
     - name: Tag commit for release (workflow_dispatch)
       if: ${{ github.event_name == 'workflow_dispatch' &&
         startsWith(inputs.mode, 'release-') }}
-      run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
+      run: git tag -f ${{ needs.prepare-release-tag.outputs.release_tag }}
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
@@ -474,8 +474,8 @@ jobs:
         TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
       run: |
         set -euo pipefail
-        git tag "$TAG"
-        git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
+        git tag -f "$TAG"
+        git push origin -f "$TAG" || { sleep 2; git push origin -f "$TAG"; }
     - name: Create release with generated notes + discussion
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When running the CI jobs, it's possible that the tag we're trying to push already exists (e.g., if a previous job failed after creating it, or we re-run the pipeline). This patch updates `git tag` to `git tag -f` and `git push origin "$TAG"` to `git push origin -f "$TAG"` in `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [3451013366380839440](https://jules.google.com/task/3451013366380839440) started by @arran4*