### PR TITLE
Update github actions to latest versions to fix github pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -41,13 +41,13 @@ jobs:
           go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './public'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update github actions to latest versions to fix github pages deployment

This commit updates the versions of github actions in the github pages
deployment workflow to their latest versions to fix the node 20
deprecation issue and github pages deployment failure.

---
*PR created automatically by Jules for task [9924102730477626664](https://jules.google.com/task/9924102730477626664) started by @arran4*