### PR TITLE
Fix GoReleaser configuration for multiple binaries

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -18,9 +18,17 @@ builds:
     flags: ["-tags=netgo", "-trimpath"]
 archives:
   -
+    id: default
+    builds:
+      - abckohlerreportrss
     format_overrides:
       - goos: windows
         format: zip
+  -
+    id: cgi
+    builds:
+      - abckohlerreportrss-cgi
+    name_template: '{{ .ProjectName }}-cgi_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/goreleaser.yaml.orig
+++ b/goreleaser.yaml.orig
@@ -19,19 +19,16 @@ builds:
 archives:
   -
     id: default
-    ids:
+    builds:
       - abckohlerreportrss
     format_overrides:
       - goos: windows
         format: zip
   -
     id: cgi
-    ids:
+    builds:
       - abckohlerreportrss-cgi
     name_template: '{{ .ProjectName }}-cgi_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-    format_overrides:
-      - goos: windows
-        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This commit fixes the `goreleaser.yaml` configuration to specify separate archives for the `abckohlerreportrss` and `abckohlerreportrss-cgi` builds. This resolves an issue where GoReleaser failed during the release process due to multiple binaries being packed into a single default archive, which caused subsequent retries to fail with a `git tag already exists` error.

---
*PR created automatically by Jules for task [1915981158333289376](https://jules.google.com/task/1915981158333289376) started by @arran4*