### PR TITLE
fix: ensure tags are fetched before computing the next version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
             release-alpha) level="patch"; suffix="alpha" ;;
             *) echo "Unsupported release mode: $MODE"; exit 1 ;;
           esac
+          git fetch --tags --force
           if command -v git-tag-inc >/dev/null 2>&1; then
             # git-tag-inc uses positional commands (patch/major/minor/test/rc...)
             # and NOT flag forms like -patch.
@@ -193,7 +194,6 @@ jobs:
             next_tag=$(git-tag-inc "${args[@]}")
           else
             # Fallback implementation when git-tag-inc is not available.
-            git fetch --tags --force
             latest=$(git tag -l 'v*' | sed 's/^v//' | sort -V | tail -n 1)
             [[ -z "$latest" ]] && latest='0.0.0'
 


### PR DESCRIPTION
Fixes an issue where `git-tag-inc` could compute a next version tag that was already on the remote repository. This happened because `git fetch --tags --force` was only being executed in the fallback block when `git-tag-inc` wasn't available. By fetching tags earlier, both tag computation paths now operate correctly.

---
*PR created automatically by Jules for task [10464379299209966252](https://jules.google.com/task/10464379299209966252) started by @arran4*