### PR TITLE
fix(goreleaser): Resolve archive error and deprecation warnings

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -21,21 +21,23 @@ archives:
     id: default
     ids:
       - abckohlerreportrss
+    allow_different_binary_count: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
   -
     id: cgi
     ids:
       - abckohlerreportrss-cgi
     name_template: '{{ .ProjectName }}-cgi_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    allow_different_binary_count: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -19,21 +19,19 @@ builds:
 archives:
   -
     id: default
-    ids:
+    builds:
       - abckohlerreportrss
-    allow_different_binary_count: true
     format_overrides:
       - goos: windows
         formats: ["zip"]
   -
     id: cgi
-    ids:
+    builds:
       - abckohlerreportrss-cgi
     name_template: '{{ .ProjectName }}-cgi_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-    allow_different_binary_count: true
     format_overrides:
       - goos: windows
-        formats: ["zip"]
+        formats: ["none"]
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Resolved GoReleaser build errors caused by missing Windows binaries in the `cgi` archive when mixing different builds. Additionally, updated to v2 configurations to eliminate multiple deprecation warnings.

---
*PR created automatically by Jules for task [510568888751035534](https://jules.google.com/task/510568888751035534) started by @arran4*