### PR TITLE
ci: fix github pages build module conflict

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,9 @@ jobs:
         run: |
           mkdir -p public/rss
           # Generate index.html from readme.md using a Go-based markdown to HTML converter
-          go run github.com/arran4/fork-mdtohtml@latest -page readme.md public/index.html
+          git clone https://github.com/arran4/fork-mdtohtml.git /tmp/fork-mdtohtml
+          (cd /tmp/fork-mdtohtml && go build -o /tmp/mdtohtml .)
+          /tmp/mdtohtml -page readme.md public/index.html
           sed -i 's/<title>.*<\/title>/<title>ABC Kohler Report RSS<\/title>/i' public/index.html
           # Generate RSS feed
           go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml


### PR DESCRIPTION
ci: fix github pages build module conflict

The github pages deployment was failing because `go run` strict validation
failed due to a module path declaration mismatch inside
github.com/arran4/fork-mdtohtml. Fix this by manually cloning and building
the module during the CI workflow to bypass module path validation.

---
*PR created automatically by Jules for task [17268928246330448241](https://jules.google.com/task/17268928246330448241) started by @arran4*