### PR TITLE
ci: gracefully exit prepare-next-version-pr if no changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,10 @@ jobs:
         # sed -i -E "s/(project\([^ ]+ VERSION )[^ )]+/\1$NEXT_VERSION/" CMakeLists.txt
 
         git add -A
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
         git commit -m "Prepare next development iteration $NEXT_VERSION"
         git push -u origin "$BRANCH"
         gh pr create --title "Prepare next development iteration $NEXT_VERSION" --body "Automated PR for next iteration." --base main --head "$BRANCH"


### PR DESCRIPTION
Fixes the CI workflow failure where `prepare-next-version-pr` fails because there is nothing to commit.

---
*PR created automatically by Jules for task [14246917832532129529](https://jules.google.com/task/14246917832532129529) started by @arran4*