### PR TITLE
ci: fix mdtohtml flag usage and output generation in pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,8 +37,10 @@ jobs:
           # Generate index.html from readme.md using a Go-based markdown to HTML converter
           git clone https://github.com/arran4/fork-mdtohtml.git /tmp/fork-mdtohtml
           (cd /tmp/fork-mdtohtml && go build -o /tmp/mdtohtml .)
-          /tmp/mdtohtml -page readme.md public/index.html
-          sed -i 's/<title>.*<\/title>/<title>ABC Kohler Report RSS<\/title>/i' public/index.html
+          /tmp/mdtohtml readme.md
+          echo '<!DOCTYPE html><html><head><title>ABC Kohler Report RSS</title></head>' > public/index.html
+          cat readme.html >> public/index.html
+          echo '</html>' >> public/index.html
           # Generate RSS feed
           go run ./cmd/abckohlerreportrss -output public/rss/abckohlerreportrss.xml
 


### PR DESCRIPTION
Fixes an issue in the GitHub Actions `pages.yml` workflow where `mdtohtml` panics when attempting to generate HTML from `readme.md`. The tool was incorrectly passed a `-page` flag and a target file path. Now, the workflow invokes `mdtohtml` properly and manually wraps the output snippet into a complete `index.html` structure.

---
*PR created automatically by Jules for task [15837774492965439892](https://jules.google.com/task/15837774492965439892) started by @arran4*