### PR TITLE
ci: replace git status --porcelain with diff-index in workflow scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
         BRANCH="ci/gofmt/${{ github.run_id }}"
         git checkout -b "$BRANCH"
         git add -A
-        if [ -z "$(git status --porcelain)" ]; then echo "No fmt changes"; exit 0; fi
+        if git diff-index --quiet HEAD --; then echo "No fmt changes"; exit 0; fi
         git commit -m "ci: go fmt"
         git push origin "$BRANCH"
         gh pr create --title "ci: go fmt" --body "Automated go fmt from manual dispatch." --base main --head "$BRANCH" --label "ci-autofix"
@@ -376,7 +376,7 @@ jobs:
         git checkout -b "$BRANCH"
         git add -A
 
-        if [ -z "$(git status --porcelain)" ]; then
+        if git diff-index --quiet HEAD --; then
           echo "No changes; exiting."
           exit 0
         fi
@@ -555,7 +555,7 @@ jobs:
         # sed -i -E "s/(project\([^ ]+ VERSION )[^ )]+/\1$NEXT_VERSION/" CMakeLists.txt
 
         git add -A
-        if [ -z "$(git status --porcelain)" ]; then
+        if git diff-index --quiet HEAD --; then
           echo "No changes to commit"
           exit 0
         fi


### PR DESCRIPTION
Using `if [ -z "$(git status --porcelain)" ]` in the CI workflow has an issue because sometimes `git status --porcelain` might output something that doesn't actually mean there are files staged for commit, resulting in a "nothing to commit, working tree clean" error from `git commit` and exiting with code 1 due to `set -e`.

Using `if git diff-index --quiet HEAD --; then` reliably checks whether there are changes staged. This replaces it globally in the CI `.github/workflows/ci.yml` file.

---
*PR created automatically by Jules for task [11305551260335824478](https://jules.google.com/task/11305551260335824478) started by @arran4*