### PR TITLE
Use latest pre-built mdtohtml binary in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,11 +32,12 @@ jobs:
           check-latest: true
 
       - name: Build site directory
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p public/rss
           # Generate index.html from readme.md using a Go-based markdown to HTML converter
-          URL=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/arran4/fork-mdtohtml/releases/latest | jq -r '.assets[] | select(.name | endswith("linux_amd64.tar.gz")) | .browser_download_url')
-          curl -sL "$URL" | tar xvz -C /tmp
+          gh release download -R arran4/fork-mdtohtml -p "*linux_amd64.tar.gz" -O - | tar xvz -C /tmp
           /tmp/mdtohtml readme.md
           echo '<!DOCTYPE html><html><head><title>ABC Kohler Report RSS</title></head>' > public/index.html
           cat readme.html >> public/index.html

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           mkdir -p public/rss
           # Generate index.html from readme.md using a Go-based markdown to HTML converter
-          git clone https://github.com/arran4/fork-mdtohtml.git /tmp/fork-mdtohtml
-          (cd /tmp/fork-mdtohtml && go build -o /tmp/mdtohtml .)
+          URL=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/arran4/fork-mdtohtml/releases/latest | jq -r '.assets[] | select(.name | endswith("linux_amd64.tar.gz")) | .browser_download_url')
+          curl -sL "$URL" | tar xvz -C /tmp
           /tmp/mdtohtml readme.md
           echo '<!DOCTYPE html><html><head><title>ABC Kohler Report RSS</title></head>' > public/index.html
           cat readme.html >> public/index.html


### PR DESCRIPTION
Updated `.github/workflows/pages.yml` to download the `linux_amd64` release tarball of `arran4/fork-mdtohtml` using the GitHub API rather than performing a git clone and a go build during the workflow. This speeds up the pages build by using the pre-built tool.

---
*PR created automatically by Jules for task [943915535708066091](https://jules.google.com/task/943915535708066091) started by @arran4*